### PR TITLE
Optimize _build_devices and sparse matrix construction

### DIFF
--- a/jax_spice/analysis/engine.py
+++ b/jax_spice/analysis/engine.py
@@ -1055,7 +1055,11 @@ class CircuitEngine:
                     shared_indices, varying_indices_list, init_to_eval_list
                 )
                 # vmap with in_axes=(None, 0) - shared broadcasts, device mapped
-                vmapped_split_init = jax.jit(jax.vmap(split_init_fn, in_axes=(None, 0)))
+                # Use cached vmapped+jit to avoid repeated JIT compilation
+                code_hash = init_split_meta.get('code_hash', '')
+                vmapped_split_init = openvaf_jax.get_vmapped_jit(
+                    code_hash, split_init_fn, in_axes=(None, 0)
+                )
 
                 # Compute cache using split init (no large init_inputs array needed!)
                 logger.info(f"Computing init cache for {model_type} ({n_devices} devices) via split init...")


### PR DESCRIPTION
## Summary
- Cache model params, device types, and SPICE number parsing in _build_devices loop
- Vectorize COO→CSR indptr construction using np.bincount
- Consolidate sparse deduplication to single pass (remove redundant jnp.unique)

## Test plan
- [x] All 258 tests pass
- [ ] Verify performance improvement on CI GPU benchmark

🤖 Generated with [Claude Code](https://claude.com/claude-code)