### PR TITLE
-V shortflag for --version

### DIFF
--- a/jax_spice/cli.py
+++ b/jax_spice/cli.py
@@ -304,7 +304,7 @@ Examples:
         """,
     )
 
-    parser.add_argument("--version", action="version", version="%(prog)s 0.1.0")
+    parser.add_argument("--version", "-V", action="version", version="%(prog)s 0.1.0")
     parser.add_argument(
         "-v", "--verbose", action="count", default=0, help="Increase verbosity (use -vv for debug)"
     )


### PR DESCRIPTION
From this issue: https://github.com/ChipFlow/jax-spice/issues/10

Because: there is no short flag -V for --version in main branch, cli.py