### PR TITLE
docs: fix AdaptiveConfig min_dt default (1e-18 -> 1e-15)

### DIFF
--- a/docs/transient_options.md
+++ b/docs/transient_options.md
@@ -88,7 +88,7 @@ engine.prepare(use_sparse=True)
 
 | AdaptiveConfig | Default | Description |
 |----------------|---------|-------------|
-| `min_dt` | 1e-18 | Minimum allowed timestep (seconds). |
+| `min_dt` | 1e-15 | Minimum allowed timestep (seconds). |
 | `max_order` | 2 | Maximum polynomial order for predictor (0=constant, 1=linear, 2=quadratic). |
 | `grow_factor` | 2.0 | Maximum factor by which timestep can grow per step. |
 | `warmup_steps` | 2 | Fixed-dt steps before enabling LTE control (need history for predictor). |

--- a/vajax/analysis/transient/adaptive.py
+++ b/vajax/analysis/transient/adaptive.py
@@ -45,7 +45,7 @@ class AdaptiveConfig:
             new_dt exceeds this, the timestep is rejected. Default 2.5.
         reltol: Relative tolerance for LTE comparison. Default 1e-3.
         abstol: Absolute tolerance for LTE comparison. Default 1e-12.
-        min_dt: Minimum allowed timestep. Default 1e-18 seconds.
+        min_dt: Minimum allowed timestep. Default 1e-15 seconds.
         max_dt: Maximum allowed timestep. Default infinity (no limit).
         warmup_steps: Number of fixed-dt steps before enabling LTE control.
             Need at least 2 past solutions for linear extrapolation. Default 2.


### PR DESCRIPTION
The `min_dt` default is documented as `1e-18` in both the `AdaptiveConfig` docstring and `docs/transient_options.md`, but the actual field default in `adaptive.py` is `1e-15`. This updates both to match the code.

Closes #43.