### PR TITLE
Fix: un-given device TEMP defaults to 0 °C instead of ambient $temperature

### DIFF
--- a/vajax/analysis/openvaf_models.py
+++ b/vajax/analysis/openvaf_models.py
@@ -767,6 +767,15 @@ def prepare_static_inputs(
             if pname not in all_unique:
                 if pname in ("tnom", "tref", "tr"):
                     default = 27.0
+                elif pname in ("temp", "temperature"):
+                    # Device operating temperature: when not given, the model must fall back to the
+                    # ambient $temperature. Compact models express this with a huge "not given"
+                    # sentinel (e.g. EKV `TEMP = -`NOT_GIVEN` = 1e21) tested as `if (TEMP == -NOT_
+                    # GIVEN)`. init_param_defaults (openvaf_py get_param_defaults) drops such computed
+                    # defaults, so without this the 0.0 fallback below reads as "0 degC given" and
+                    # the device runs at 273.15 K instead of the ambient. (Deeper fix: teach
+                    # get_param_defaults to capture sentinel/computed defaults.)
+                    default = 1e21
                 elif pname in ("nf", "mult", "ns", "nd"):
                     default = 1.0
                 else:


### PR DESCRIPTION
## Problem

When a device does **not** specify `TEMP`, VAJAX passes the parameter to the compiled model as
**`0.0`** — read by the model as "0 °C was given" — instead of the Verilog-A "not given" sentinel
`-\`NOT_GIVEN` (`= +1e21` for models using `` `define NOT_GIVEN -1.0e21``). The model therefore
takes `T = TEMP + 273.15 = 273.15 K` (0 °C) rather than falling back to the ambient
`$temperature`. Every device silently runs **27 °C too cold**.

Root cause: in `prepare_static_inputs` (`vajax/analysis/openvaf_models.py`), un-given `tnom/tref/tr`
were special-cased but un-given `temp`/`temperature` fell through to the generic `0.0` fallback
(`get_param_defaults()` drops computed/sentinel defaults like `-\`NOT_GIVEN`, so nothing supplied
the right value).

## Fix

Default un-given `temp`/`temperature` to the `-\`NOT_GIVEN` sentinel (`1e21`) so the model's own
"not given → `$temperature`" branch runs.

## Evidence

On EKV at `Vg=0.7, Vd=1.0`: the device now reports `T=300.15 K`, `Vt=0.025865`, and `Id` moves
`5.32 → 7.17 µA` — matching an independent VACASK/OSDI run of the same `.va` at the ambient.

## Note

A deeper alternative would be to teach the openvaf_py `get_param_defaults()` extraction to emit
computed/sentinel defaults (so the runtime fallback need not special-case temperature names). This
PR is the minimal, targeted runtime fix. A companion PR fixes the *nominal* temperature (`TNOM`).
