### PR TITLE
Fix: nominal temperature Tnom runs at 0 °C — init param misrouted to hidden_state slot

### DIFF
--- a/vajax/analysis/openvaf_models.py
+++ b/vajax/analysis/openvaf_models.py
@@ -510,8 +510,32 @@ def compile_openvaf_models(
             f"  {model_type}: init function done in {t4 - t3:.1f}s (cache_size={init_meta['cache_size']})"
         )
 
-        # Build init->eval index mapping
-        eval_name_to_idx = {n.lower(): i for i, n in enumerate(param_names)}
+        # Build init->eval index mapping (case-insensitive).
+        # An init param sources its runtime *value* from the eval input slot of the same name. A
+        # model can expose several eval slots that collide when lowercased: a value `param`, its
+        # `param_given` flag, and a `hidden_state` cache slot (e.g. EKV `TNOM`/`Tnom`; BSIM4
+        # exposes all three for `tnom`, `vth0`, `u0`, ...). A naive last-wins lowercase map points
+        # the init param at whichever comes last — the hidden_state (an init *output*, value 0.0)
+        # or the given-flag (0/1) — silently corrupting the parameter. Rank by preference so a
+        # value-param always reads its value: value-input > param_given > hidden_state; last-wins
+        # within a tier (legacy behaviour among equal-preference slots).
+        _VALUE_INPUT_KINDS = frozenset(
+            {"param", "temperature", "voltage", "implicit_unknown", "sysfun"}
+        )
+
+        def _name_pref(kind: str) -> int:
+            if kind in _VALUE_INPUT_KINDS:
+                return 2
+            if kind == "param_given":
+                return 1
+            return 0  # hidden_state and everything else (init outputs)
+
+        eval_name_to_idx: Dict[str, int] = {}
+        for i, n in enumerate(param_names):
+            key = n.lower()
+            prev = eval_name_to_idx.get(key)
+            if prev is None or _name_pref(param_kinds[i]) >= _name_pref(param_kinds[prev]):
+                eval_name_to_idx[key] = i
         init_to_eval_indices = []
         for name in init_meta["param_names"]:
             eval_idx = eval_name_to_idx.get(name.lower(), -1)
@@ -766,7 +790,13 @@ def prepare_static_inputs(
         for pname, cols in param_to_cols.items():
             if pname not in all_unique:
                 if pname in ("tnom", "tref", "tr"):
-                    default = 27.0
+                    # Un-given nominal temperature. Prefer the model's own literal default; if
+                    # the model expresses "not given" via the -`NOT_GIVEN sentinel idiom (EKV:
+                    # `if (TNOM == -`NOT_GIVEN) Tnom = `DEFAULT_TNOM + `P_CELSIUS0`), then
+                    # get_param_defaults drops that computed default, so fall back to the sentinel
+                    # and let the model select its own DEFAULT_TNOM (matches VACASK) rather than
+                    # reading a spurious 0/27 degC.
+                    default = model_defaults.get(pname, 1e21)
                 elif pname in ("nf", "mult", "ns", "nd"):
                     default = 1.0
                 else:


### PR DESCRIPTION
## Problem

A model's **nominal** temperature `Tnom` can silently run at **0 °C** instead of its intended
default (e.g. EKV's `DEFAULT_TNOM = 25 °C`), mis-scaling every `pow(ratioT, BEX)` mobility/threshold
temperature correction.

Root cause is a **case-insensitive parameter-name collision** in the init→eval index map
(`vajax/analysis/openvaf_models.py`, `compile_openvaf_models`). A model can expose both an *input*
param and a same-named *hidden_state* cache slot that collide when lowercased — EKV exposes input
`TNOM` (kind=`param`) and hidden_state `Tnom` (kind=`hidden_state`). The map was built last-wins:

```python
eval_name_to_idx = {n.lower(): i for i, n in enumerate(param_names)}
```

so `'tnom'` resolved to the **hidden_state** slot. Init params are *inputs*, but the generated init
function then sourced `TNOM`'s value from that hidden_state slot — pre-initialized to **0.0** — so
the model computed `Tnom = 0 + `P_CELSIUS0 = 273.15 K`.

## Fix

Two changes:

1. **init→eval map:** on a lowercase collision, prefer a real *input* kind
   (`param`/`param_given`/`temperature`/`voltage`/`implicit_unknown`/`sysfun`) over `hidden_state`,
   while preserving legacy last-wins *among entries of the same preference* (so a `param` and its
   `param_given` twin are untouched). This is the load-bearing fix — init inputs must never source
   from a hidden_state (init-output) slot.
2. **un-given nominal-temp default:** `tnom/tref/tr` fall back to the `-\`NOT_GIVEN` sentinel
   (`model_defaults.get(pname, 1e21)`) so the model selects its own `DEFAULT_TNOM`.

## Evidence

EKV `Id` at `Vg=0.7, Vd=1.0` goes `7.17 → 5.9588 µA`, matching an independent VACASK/OSDI run of the
same `.va` **exactly** (ratio 1.0000); every `d(Id)/dθ` matches to 0.00%.

**Blast radius** (compiled all 11 bundled models): every mapping the fix changes is
`hidden_state → input` — the same shadowed-input bug — `ekv` (TNOM), `bsimimg` (WR, TNOM), `bsimcmg`
(RHORSD, TNOM, NVTM, CGSP, CGDP), `bsimbulk` (RBxx, TNOM), `hisim2` (mfactor, NFALP1/2, NSUBD/NW).
There are **no** `param ↔ param_given` flips. All are latent "init input silently read as 0.0" bugs,
so the promotion is strictly a correctness improvement (these models were not previously
numerically re-validated against VACASK — worth a look during their bring-up).

## Note

The cleanest upstream fix for the default half would be teaching openvaf_py `get_param_defaults()`
to emit sentinel/computed defaults, so the runtime fallback need never guess. The map fix (change 1)
is independent of that and is the essential correctness fix. A companion PR fixes the *device*
temperature (`TEMP`); this PR is independent of it.
